### PR TITLE
New Orchestrator section

### DIFF
--- a/source/release-notes-ps-v8.0.28.rst
+++ b/source/release-notes-ps-v8.0.28.rst
@@ -25,6 +25,11 @@ The following lists a number of the bug fixes for *MySQL* 8.0.28, provided by Or
 
 Find the full list of bug fixes and changes in the `MySQL 8.0.28 Release Notes <https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-28.html>`__.
 
+Orchestrator
+=================================================
+
+:jirabug:`DISTMYSQL-141`: In complicated environments, such as 3 or more datacenters, or when each server has more than 2 intermediary masters, Orchestrator could miss replication delays in one or more datacenters. This was happening due to a hard-coded limitation of two intermediary masters to check for the replication delay. This is now fixed.
+
 ---------------------------------------------
 
 The following is the list of components supplied with |PS|-based deployment variant of |pdmysql|:  


### PR DESCRIPTION
Added a new Orchestrator section to have a way to cite the fixes included in this tool.
Mentioned fix of issue DISTMYSQL-141.

Still open (can be in a different PR):
- Cite the correct version number in the table: 3.2.6-x, instead of 3.2.6