### PR TITLE
Adding a note on dependencies

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -14,6 +14,13 @@ Like other Percona products, we recommend to install Percona Distribution for My
 
     The disadvantage of using a Minor Release repository is that you are locked in this particular release. When potentially critical fixes are released in a later minor version of the database, you will not be prompted for an upgrade by the package manager of your operating system. You would need to change the configured repository in order to install the upgrade.
 
+## Install GnuPG and curl
+Install `gnupg2` and `curl`, if not already installed. Those packages are required for installing Percona Distribution for MySQL.
+
+```sh
+$ sudo apt install gnupg2 curl
+```
+
 ## Install `percona-release` utility
 
 [Install percona-release](https://www.percona.com/doc/percona-repo-config/installing.html). If you have it installed, [update percona-release](https://www.percona.com/doc/percona-repo-config/updating.html) to the latest version.


### PR DESCRIPTION
During installation of `percona-server-server`, following the instructions [here](https://docs.percona.com/percona-distribution-for-mysql/8.0/installing.html#install-percona-distribution-for-mysql-packages). I got the following error message:

```
/usr/share/mysql/mysql-helpers: line 73: 13537 Killed                  mysqld --defaults-group-suffix="$2" --user=mysql --init-file="$
1" --socket="$tmpdir/mysqld.sock" --pid-file="$tmpdir/mysqld.pid" > /dev/null 2>&1
dpkg: error processing package percona-server-server (--configure):
 installed percona-server-server package post-installation script subprocess returned error exit status 137
Processing triggers for systemd (245.4-4ubuntu3.17) ...
Processing triggers for man-db (2.9.1-1) ...
Processing triggers for libc-bin (2.31-0ubuntu9.9) ...
Errors were encountered while processing:
 percona-server-server
E: Sub-process /usr/bin/dpkg returned an error code (1)
```
Getting the same error on both Ubuntu and Debian, configured on a Vagrant virtual environment. The solution was to install GnuPG and curl before installing Percona Distribution for MySQL, as mentioned [here](https://docs.percona.com/percona-server/8.0/installation/apt_repo.html).