### PR TITLE
Add link to rel. notes of percona toolkit v3.4.0

### DIFF
--- a/docs/release-notes-ps-v8.0.29.md
+++ b/docs/release-notes-ps-v8.0.29.md
@@ -50,6 +50,6 @@ The following is the list of components supplied with *Percona Server for MySQL*
 | Orchestrator        | [3.2.6-3](https://github.com/percona/orchestrator/releases/tag/v3.2.6-3)     | The replication topology manager for Percona Server for MySQL|
 | ProxySQL            | [2.3.2](https://docs.percona.com/proxysql/release-notes-2.3.2-1.html)     | A high performance, high-availability, protocol-aware proxy for MySQL|
 | Percona XtraBackup  | [8.0.29-22](https://docs.percona.com/percona-xtrabackup/latest/release-notes/8.0/8.0.29-22.0.html)| An open-source hot backup utility for MySQL-based servers|
-| Percona Toolkit     | 3.4.0     | The set of scripts to simplify and optimize database operation|
+| Percona Toolkit     | [3.4.0](https://www.percona.com/doc/percona-toolkit/LATEST/release_notes.html#v3-4-0-released-2022-07-11)     | The set of scripts to simplify and optimize database operation|
 | MySQL Shell         | [8.0.29](https://dev.mysql.com/doc/relnotes/mysql-shell/8.0/en/news-8-0-29.html)    | An advanced client and code editor for MySQL Server|
 | MySQL Router        | [8.0.29](https://dev.mysql.com/doc/relnotes/mysql-router/en/news-8-0-29.html)    | Lightweight middleware that provides transparent routing between your application and back-end MySQL servers|


### PR DESCRIPTION
Starting from v8.0.29, we have added links in the [table](https://docs.percona.com/percona-distribution-for-mysql/8.0/release-notes-ps-v8.0.29.html) of the tools included with Percona Distribution for MySQL.
Link to the release notes of Percona Toolkit v3.4.0 was missing. This PR adds it.

This PR is depended on https://github.com/percona/percona-toolkit/pull/548 and can be merged only after https://github.com/percona/percona-toolkit/pull/548 is merged (otherwise the link added here will not work). Update: https://github.com/percona/percona-toolkit/pull/548 has now been merged.